### PR TITLE
SSE and Stream support

### DIFF
--- a/agentuity/server/__init__.py
+++ b/agentuity/server/__init__.py
@@ -289,9 +289,16 @@ async def handle_agent_request(request: web.Request):
                 response = await response
 
                 if isinstance(response, AgentResponse):
+                    payload = response.payload
+                    if response.is_stream:
+                        payload = ""
+                        for chunk in response:
+                            if chunk is not None:
+                                payload += chunk
+                        payload = encode_payload(payload)
                     response = {
                         "contentType": response.content_type,
-                        "payload": response.payload,
+                        "payload": payload,
                         "metadata": response.metadata,
                     }
                 elif isinstance(response, RemoteAgentResponse):

--- a/agentuity/server/__init__.py
+++ b/agentuity/server/__init__.py
@@ -7,6 +7,7 @@ import asyncio
 import aiohttp
 import platform
 from aiohttp import web
+from aiohttp_sse import sse_response
 import base64
 
 from opentelemetry import trace
@@ -212,7 +213,7 @@ async def handle_run_request(request):
             return resp
 
 
-async def handle_agent_request(request):
+async def handle_agent_request(request: web.Request):
     # Access the agents_by_id from the app state
     agents_by_id = request.app["agents_by_id"]
 
@@ -250,10 +251,42 @@ async def handle_agent_request(request):
             },
         ) as span:
             try:
+                is_sse = request.headers.get("accept") == "text/event-stream"
+
                 # Call the run function and get the response
-                response = await run_agent(
-                    tracer, agentId, agent, payload, agents_by_id
-                )
+                response = run_agent(tracer, agentId, agent, payload, agents_by_id)
+
+                # Prepare response headers
+                headers = {}  # Don't include Content-Type in headers
+                inject_trace_context(headers)
+
+                # handle server side events
+                if is_sse:
+                    async with sse_response(request, headers=headers) as resp:
+                        response = await response
+                        if not isinstance(response, AgentResponse):
+                            return web.Response(
+                                text="Expected a AgentResponse response when using SSE",
+                                status=500,
+                                headers=headers,
+                                content_type="text/plain",
+                            )
+                        if not response.is_stream:
+                            return web.Response(
+                                text="Expected a stream response when using SSE",
+                                status=500,
+                                headers=headers,
+                                content_type="text/plain",
+                            )
+                        for chunk in response:
+                            if chunk is None:
+                                resp.force_close()
+                                break
+                            await resp.send(chunk)
+                    return resp
+
+                # handle normal response
+                response = await response
 
                 if isinstance(response, AgentResponse):
                     response = {
@@ -293,10 +326,6 @@ async def handle_agent_request(request):
                     }
                 else:
                     raise ValueError("Unsupported response type")
-
-                # Prepare response headers
-                headers = {}  # Don't include Content-Type in headers
-                inject_trace_context(headers)
 
                 span.set_status(trace.Status(trace.StatusCode.OK))
                 return web.json_response(response, headers=headers)

--- a/agentuity/server/agent.py
+++ b/agentuity/server/agent.py
@@ -7,14 +7,42 @@ from opentelemetry.propagate import inject
 
 
 class RemoteAgentResponse:
+    """
+    A container class for responses from remote agent invocations. This class provides
+    structured access to the response data, content type, and metadata.
+    """
+
     def __init__(self, data: dict):
+        """
+        Initialize a RemoteAgentResponse with response data.
+
+        Args:
+            data: Dictionary containing:
+                - payload: The response data
+                - contentType: The MIME type of the response
+                - metadata: Optional metadata associated with the response
+        """
         self.data = Data(data)
         self.contentType = data.get("contentType", "text/plain")
         self.metadata = data.get("metadata", {})
 
 
 class RemoteAgent:
+    """
+    A client for invoking remote agents. This class provides methods to communicate
+    with agents running in a separate process, supporting various data types and
+    distributed tracing.
+    """
+
     def __init__(self, agentconfig: AgentConfig, port: int, tracer: trace.Tracer):
+        """
+        Initialize the RemoteAgent client.
+
+        Args:
+            agentconfig: Configuration for the remote agent
+            port: Port number where the agent is listening
+            tracer: OpenTelemetry tracer for distributed tracing
+        """
         self.agentconfig = agentconfig
         self._port = port
         self._tracer = tracer
@@ -26,6 +54,25 @@ class RemoteAgent:
         content_type: str = "text/plain",
         metadata: Optional[dict] = None,
     ) -> RemoteAgentResponse:
+        """
+        Invoke the remote agent with the provided data.
+
+        Args:
+            data: The data to send to the agent. Can be:
+                - Data object
+                - bytes
+                - str, int, float, bool
+                - list or dict (will be converted to JSON)
+            base64: Optional pre-encoded base64 data to send instead of encoding the data parameter
+            content_type: The MIME type of the data (default: "text/plain")
+            metadata: Optional metadata to include with the request
+
+        Returns:
+            RemoteAgentResponse: The response from the remote agent
+
+        Raises:
+            Exception: If the agent invocation fails or returns an error status
+        """
         with self._tracer.start_as_current_span("remoteagent.run") as span:
             span.set_attribute("remote.agentId", self.agentconfig.id)
             span.set_attribute("remote.agentName", self.agentconfig.name)
@@ -58,4 +105,10 @@ class RemoteAgent:
                 return RemoteAgentResponse(data)
 
     def __str__(self) -> str:
+        """
+        Get a string representation of the remote agent.
+
+        Returns:
+            str: A formatted string containing the agent configuration
+        """
         return f"RemoteAgent(agentconfig={self.agentconfig})"

--- a/agentuity/server/config.py
+++ b/agentuity/server/config.py
@@ -1,38 +1,67 @@
 class AgentConfig:
     """
-    the config for the agent
+    Configuration class for an agent. This class provides a structured way to access
+    agent configuration properties including ID, name, description, and filename.
     """
 
     def __init__(self, config: dict):
+        """
+        Initialize the AgentConfig with a configuration dictionary.
+
+        Args:
+            config: Dictionary containing agent configuration with the following keys:
+                - id: Unique identifier for the agent
+                - name: Display name of the agent
+                - description: Description of the agent's purpose
+                - filename: Path to the agent's file relative to the dist directory
+        """
         self._config = config
 
     @property
     def id(self) -> str:
         """
-        the unique id of the agent
+        Get the unique identifier of the agent.
+
+        Returns:
+            str: The unique identifier of the agent, or None if not set
         """
         return self._config.get("id")
 
     @property
     def name(self) -> str:
         """
-        the name of the agent
+        Get the display name of the agent.
+
+        Returns:
+            str: The display name of the agent, or None if not set
         """
         return self._config.get("name")
 
     @property
     def description(self) -> str:
         """
-        the description of the agent
+        Get the description of the agent.
+
+        Returns:
+            str: The description of the agent's purpose, or None if not set
         """
         return self._config.get("description")
 
     @property
     def filename(self) -> str:
         """
-        the file name to the agent relative to the dist directory
+        Get the filename of the agent relative to the dist directory.
+
+        Returns:
+            str: The path to the agent's file relative to the dist directory, or None if not set
         """
         return self._config.get("filename")
 
     def __str__(self) -> str:
+        """
+        Get a string representation of the agent configuration.
+
+        Returns:
+            str: A formatted string containing all agent configuration properties
+        """
         return f"AgentConfig(id={self.id}, name={self.name}, description={self.description}, filename={self.filename})"

--- a/agentuity/server/context.py
+++ b/agentuity/server/context.py
@@ -7,7 +7,8 @@ from .agent import RemoteAgent
 
 class AgentContext:
     """
-    the context of the agent invocation
+    The context of the agent invocation. This class provides access to all the necessary
+    services, configuration, and environment information needed during agent execution.
     """
 
     def __init__(
@@ -19,6 +20,19 @@ class AgentContext:
         agents_by_id: dict,
         port: int,
     ):
+        """
+        Initialize the AgentContext with required services and configuration.
+
+        Args:
+            services: Dictionary containing service instances:
+                - kv: Key-value store service
+                - vector: Vector store service
+            logger: Logging instance for the agent
+            tracer: OpenTelemetry tracer for distributed tracing
+            agent: Dictionary containing the current agent's configuration
+            agents_by_id: Dictionary mapping agent IDs to their configurations
+            port: Port number for agent communication
+        """
         self._port = port
 
         """
@@ -77,6 +91,18 @@ class AgentContext:
             self.agents.append(AgentConfig(agent))
 
     def get_agent(self, agent_id_or_name: str) -> "RemoteAgent":
+        """
+        Retrieve a RemoteAgent instance by its ID or name.
+
+        Args:
+            agent_id_or_name: The unique identifier or display name of the agent
+
+        Returns:
+            RemoteAgent: The requested agent instance
+
+        Raises:
+            ValueError: If no agent is found with the given ID or name
+        """
         for agent in self.agents:
             if agent.id == agent_id_or_name or agent.name == agent_id_or_name:
                 return RemoteAgent(agent, self._port, self.tracer)

--- a/agentuity/server/keyvalue.py
+++ b/agentuity/server/keyvalue.py
@@ -8,7 +8,9 @@ from opentelemetry import trace
 
 class KeyValueStore:
     """
-    a key value store for storing and retrieving key value pairs
+    A key-value store client for storing and retrieving key-value pairs. This class provides
+    methods to interact with a key-value storage service, supporting operations like getting,
+    setting, and deleting values with optional TTL (Time To Live) and content type specifications.
     """
 
     def __init__(
@@ -17,13 +19,31 @@ class KeyValueStore:
         api_key: str,
         tracer: trace.Tracer,
     ):
+        """
+        Initialize the KeyValueStore client.
+
+        Args:
+            base_url: The base URL of the key-value storage service
+            api_key: The API key for authentication
+            tracer: OpenTelemetry tracer for distributed tracing
+        """
         self.base_url = base_url
         self.api_key = api_key
         self.tracer = tracer
 
     async def get(self, name: str, key: str) -> DataResult:
         """
-        get a value from the key value storage
+        Retrieve a value from the key-value storage.
+
+        Args:
+            name: The name of the key-value collection
+            key: The key to retrieve
+
+        Returns:
+            DataResult: A container containing the retrieved data if found, or None if not found
+
+        Raises:
+            Exception: If the retrieval operation fails
         """
         with self.tracer.start_as_current_span("agentuity.keyvalue.get") as span:
             span.set_attribute("name", name)
@@ -66,7 +86,23 @@ class KeyValueStore:
         params: Optional[dict] = None,
     ):
         """
-        set a value in the key value storage
+        Store a value in the key-value storage.
+
+        Args:
+            name: The name of the key-value collection
+            key: The key to store the value under
+            value: The value to store. Can be:
+                - Data object
+                - bytes
+                - str, int, float, bool
+                - list or dict (will be converted to JSON)
+            params: Optional dictionary containing:
+                - ttl: Time to live in seconds (minimum 60 seconds)
+                - contentType: The MIME type of the value
+
+        Raises:
+            ValueError: If TTL is less than 60 seconds
+            Exception: If the storage operation fails or value encoding fails
         """
         with self.tracer.start_as_current_span("agentuity.keyvalue.set") as span:
             span.set_attribute("name", name)
@@ -113,7 +149,14 @@ class KeyValueStore:
 
     async def delete(self, name: str, key: str):
         """
-        delete a value in the key value storage
+        Delete a value from the key-value storage.
+
+        Args:
+            name: The name of the key-value collection
+            key: The key to delete
+
+        Raises:
+            Exception: If the deletion operation fails
         """
         with self.tracer.start_as_current_span("agentuity.keyvalue.delete") as span:
             span.set_attribute("name", name)

--- a/agentuity/server/request.py
+++ b/agentuity/server/request.py
@@ -4,15 +4,36 @@ from .data import Data
 
 class AgentRequest(dict):
     """
-    The request that triggered the agent invocation
+    The request that triggered the agent invocation. This class extends dict to provide
+    additional functionality for handling agent requests while maintaining dictionary-like
+    behavior.
     """
 
     def __init__(self, req: dict):
+        """
+        Initialize an AgentRequest object.
+
+        Args:
+            req: Dictionary containing the request data with required fields:
+                - contentType: The MIME type of the request data
+                - trigger: The event that triggered this request
+                - data: The actual request data
+                - metadata: Optional metadata associated with the request
+        """
         self._req = req
         self._data = Data(req)
         super().__init__(req)
 
     def validate(self) -> bool:
+        """
+        Validate that the request contains all required fields.
+
+        Returns:
+            bool: True if validation passes
+
+        Raises:
+            ValueError: If required fields 'contentType' or 'trigger' are missing
+        """
         if not self._req.get("contentType"):
             raise ValueError("Request must contain 'contentType' field")
         if not self._req.get("trigger"):
@@ -22,29 +43,54 @@ class AgentRequest(dict):
     @property
     def data(self) -> "Data":
         """
-        get the data of the request
+        Get the data object associated with the request.
+
+        Returns:
+            Data: The request data object containing the actual content and its type
         """
         return self._data
 
     @property
     def trigger(self) -> str:
         """
-        get the trigger of the request
+        Get the trigger that initiated this request.
+
+        Returns:
+            str: The trigger identifier that caused this request to be processed
         """
         return self._req.get("trigger")
 
     @property
     def metadata(self) -> dict:
         """
-        get the metadata of the request
+        Get the metadata associated with the request.
+
+        Returns:
+            dict: Dictionary containing any additional metadata associated with the request.
+                Returns an empty dictionary if no metadata is present.
         """
         return self._req.get("metadata", {})
 
     def get(self, key: str, default: Any = None) -> Any:
         """
-        get a value from the metadata of the request
+        Get a value from the request metadata.
+
+        Args:
+            key: The key to look up in the metadata
+            default: Default value to return if the key is not found
+
+        Returns:
+            Any: The value associated with the key in metadata, or the default value
+                if the key is not found
         """
         return self.metadata.get(key, default)
 
     def __str__(self) -> str:
+        """
+        Get a string representation of the request.
+
+        Returns:
+            str: A formatted string containing the request's trigger, content type,
+                data, and metadata
+        """
         return f"AgentRequest(trigger={self.trigger}, contentType={self._data.contentType}, data={self._data.base64}, metadata={self.metadata})"

--- a/agentuity/server/response.py
+++ b/agentuity/server/response.py
@@ -14,6 +14,15 @@ class AgentResponse:
     def __init__(
         self, payload: dict, tracer: trace.Tracer, agents_by_id: dict, port: int
     ):
+        """
+        Initialize an AgentResponse object.
+
+        Args:
+            payload: The initial payload data
+            tracer: OpenTelemetry tracer for distributed tracing
+            agents_by_id: Dictionary mapping agent IDs to their configurations
+            port: Port number for agent communication
+        """
         self.content_type = "text/plain"
         self.payload = ""
         self.metadata = {}
@@ -26,7 +35,18 @@ class AgentResponse:
         self, params: dict, args: Optional[dict] = None, metadata: Optional[dict] = None
     ) -> "AgentResponse":
         """
-        handoff the current request another agent within the same project
+        Handoff the current request to another agent within the same project.
+
+        Args:
+            params: Dictionary containing either 'id' or 'name' to identify the target agent
+            args: Optional arguments to pass to the target agent
+            metadata: Optional metadata to pass to the target agent
+
+        Returns:
+            AgentResponse: The response from the target agent
+
+        Raises:
+            ValueError: If agent is not found by id or name
         """
         if "id" not in params and "name" not in params:
             raise ValueError("params must have an id or name")
@@ -61,22 +81,61 @@ class AgentResponse:
         return self
 
     def empty(self, metadata: Optional[dict] = None) -> "AgentResponse":
+        """
+        Set an empty response with optional metadata.
+
+        Args:
+            metadata: Optional metadata to include with the response
+
+        Returns:
+            AgentResponse: The response object with empty payload
+        """
         self.metadata = metadata
         return self
 
     def text(self, data: str, metadata: Optional[dict] = None) -> "AgentResponse":
+        """
+        Set a plain text response.
+
+        Args:
+            data: The text content to send
+            metadata: Optional metadata to include with the response
+
+        Returns:
+            AgentResponse: The response object with text content
+        """
         self.content_type = "text/plain"
         self.payload = encode_payload(data)
         self.metadata = metadata
         return self
 
     def html(self, data: str, metadata: Optional[dict] = None) -> "AgentResponse":
+        """
+        Set an HTML response.
+
+        Args:
+            data: The HTML content to send
+            metadata: Optional metadata to include with the response
+
+        Returns:
+            AgentResponse: The response object with HTML content
+        """
         self.content_type = "text/html"
         self.payload = encode_payload(data)
         self.metadata = metadata
         return self
 
     def json(self, data: dict, metadata: Optional[dict] = None) -> "AgentResponse":
+        """
+        Set a JSON response.
+
+        Args:
+            data: The dictionary to be JSON encoded
+            metadata: Optional metadata to include with the response
+
+        Returns:
+            AgentResponse: The response object with JSON content
+        """
         self.content_type = "application/json"
         self.payload = encode_payload(json.dumps(data))
         self.metadata = metadata
@@ -88,47 +147,186 @@ class AgentResponse:
         content_type: str = "application/octet-stream",
         metadata: Optional[dict] = None,
     ) -> "AgentResponse":
+        """
+        Set a binary response with specified content type.
+
+        Args:
+            data: The binary data to send
+            content_type: The MIME type of the binary data
+            metadata: Optional metadata to include with the response
+
+        Returns:
+            AgentResponse: The response object with binary content
+        """
         self.content_type = content_type
         self.payload = encode_payload(data)
         self.metadata = metadata
         return self
 
     def pdf(self, data: bytes, metadata: Optional[dict] = None) -> "AgentResponse":
+        """
+        Set a PDF response.
+
+        Args:
+            data: The PDF binary data
+            metadata: Optional metadata to include with the response
+
+        Returns:
+            AgentResponse: The response object with PDF content
+        """
         return self.binary(data, "application/pdf", metadata)
 
     def png(self, data: bytes, metadata: Optional[dict] = None) -> "AgentResponse":
+        """
+        Set a PNG image response.
+
+        Args:
+            data: The PNG binary data
+            metadata: Optional metadata to include with the response
+
+        Returns:
+            AgentResponse: The response object with PNG content
+        """
         return self.binary(data, "image/png", metadata)
 
     def jpeg(self, data: bytes, metadata: Optional[dict] = None) -> "AgentResponse":
+        """
+        Set a JPEG image response.
+
+        Args:
+            data: The JPEG binary data
+            metadata: Optional metadata to include with the response
+
+        Returns:
+            AgentResponse: The response object with JPEG content
+        """
         return self.binary(data, "image/jpeg", metadata)
 
     def gif(self, data: bytes, metadata: Optional[dict] = None) -> "AgentResponse":
+        """
+        Set a GIF image response.
+
+        Args:
+            data: The GIF binary data
+            metadata: Optional metadata to include with the response
+
+        Returns:
+            AgentResponse: The response object with GIF content
+        """
         return self.binary(data, "image/gif", metadata)
 
     def webp(self, data: bytes, metadata: Optional[dict] = None) -> "AgentResponse":
+        """
+        Set a WebP image response.
+
+        Args:
+            data: The WebP binary data
+            metadata: Optional metadata to include with the response
+
+        Returns:
+            AgentResponse: The response object with WebP content
+        """
         return self.binary(data, "image/webp", metadata)
 
     def webm(self, data: bytes, metadata: Optional[dict] = None) -> "AgentResponse":
+        """
+        Set a WebM video response.
+
+        Args:
+            data: The WebM binary data
+            metadata: Optional metadata to include with the response
+
+        Returns:
+            AgentResponse: The response object with WebM content
+        """
         return self.binary(data, "video/webm", metadata)
 
     def mp3(self, data: bytes, metadata: Optional[dict] = None) -> "AgentResponse":
+        """
+        Set an MP3 audio response.
+
+        Args:
+            data: The MP3 binary data
+            metadata: Optional metadata to include with the response
+
+        Returns:
+            AgentResponse: The response object with MP3 content
+        """
         return self.binary(data, "audio/mpeg", metadata)
 
     def mp4(self, data: bytes, metadata: Optional[dict] = None) -> "AgentResponse":
+        """
+        Set an MP4 video response.
+
+        Args:
+            data: The MP4 binary data
+            metadata: Optional metadata to include with the response
+
+        Returns:
+            AgentResponse: The response object with MP4 content
+        """
         return self.binary(data, "video/mp4", metadata)
 
     def m4a(self, data: bytes, metadata: Optional[dict] = None) -> "AgentResponse":
+        """
+        Set an M4A audio response.
+
+        Args:
+            data: The M4A binary data
+            metadata: Optional metadata to include with the response
+
+        Returns:
+            AgentResponse: The response object with M4A content
+        """
         return self.binary(data, "audio/m4a", metadata)
 
     def wav(self, data: bytes, metadata: Optional[dict] = None) -> "AgentResponse":
+        """
+        Set a WAV audio response.
+
+        Args:
+            data: The WAV binary data
+            metadata: Optional metadata to include with the response
+
+        Returns:
+            AgentResponse: The response object with WAV content
+        """
         return self.binary(data, "audio/wav", metadata)
 
     def ogg(self, data: bytes, metadata: Optional[dict] = None) -> "AgentResponse":
+        """
+        Set an OGG audio response.
+
+        Args:
+            data: The OGG binary data
+            metadata: Optional metadata to include with the response
+
+        Returns:
+            AgentResponse: The response object with OGG content
+        """
         return self.binary(data, "audio/ogg", metadata)
 
     def stream(
-        self, data: Iterable[Any], transform: Callable[[Any], str]
+        self, data: Iterable[Any], transform: Optional[Callable[[Any], str]] = None
     ) -> "AgentResponse":
+        """
+        Sets up streaming response from an iterable data source.
+
+        Args:
+            data: An iterable containing the data to stream. Can be any type of iterable
+                (list, generator, etc.) containing any type of data.
+            transform: Optional callable function that transforms each item in the stream
+                into a string. If not provided, items are returned as-is.
+
+        Returns:
+            AgentResponse: The response object configured for streaming. The response can
+                then be iterated over to yield the streamed data.
+
+        Example:
+            >>> response.stream([1, 2, 3], transform=str)
+            >>> for item in response:
+            ...     print(item)
+        """
         self.content_type = "text/plain"
         self.payload = ""
         self.metadata = None
@@ -138,14 +336,40 @@ class AgentResponse:
 
     @property
     def is_stream(self) -> bool:
+        """
+        Check if the response is configured for streaming.
+
+        Returns:
+            bool: True if the response is a stream, False otherwise
+        """
         return self._stream is not None
 
     def __iter__(self):
+        """
+        Make the response object iterable for streaming.
+
+        Returns:
+            AgentResponse: The response object itself as an iterator
+
+        Raises:
+            StopIteration: If the response is not configured for streaming
+        """
         if not self.is_stream:
             raise StopIteration
         return self
 
     def __next__(self):
+        """
+        Get the next item from the stream.
+
+        Returns:
+            Any: The next item from the stream, transformed if a transform function is set
+
+        Raises:
+            StopIteration: If the stream is exhausted or not configured for streaming
+        """
         if not self.is_stream:
             raise StopIteration
-        return self._transform(next(self._stream))
+        if self._transform:
+            return self._transform(next(self._stream))
+        return next(self._stream)

--- a/agentuity/server/vector.py
+++ b/agentuity/server/vector.py
@@ -25,17 +25,40 @@ class VectorSearchResult:
 
 class VectorStore:
     """
-    a vector store for storing and searching vectors
+    A vector store for storing and searching vectors. This class provides methods to interact
+    with a vector storage service, supporting operations like upserting, retrieving, searching,
+    and deleting vectors.
     """
 
     def __init__(self, base_url: str, api_key: str, tracer: trace.Tracer):
+        """
+        Initialize the VectorStore client.
+
+        Args:
+            base_url: The base URL of the vector storage service
+            api_key: The API key for authentication
+            tracer: OpenTelemetry tracer for distributed tracing
+        """
         self.base_url = base_url
         self.api_key = api_key
         self.tracer = tracer
 
     async def upsert(self, name: str, documents: list[dict]) -> list[str]:
         """
-        upsert a vector into the vector storage
+        Upsert vectors into the vector storage.
+
+        Args:
+            name: The name of the vector collection
+            documents: List of documents to upsert. Each document must contain:
+                - key: Required field identifying the document
+                - Either 'document' or 'embeddings' field
+
+        Returns:
+            list[str]: List of IDs of the upserted documents
+
+        Raises:
+            ValueError: If documents are missing required fields
+            Exception: If the upsert operation fails
         """
         with self.tracer.start_as_current_span("agentuity.vector.upsert") as span:
             span.set_attribute("name", name)
@@ -72,7 +95,18 @@ class VectorStore:
 
     async def get(self, name: str, key: str) -> list[VectorSearchResult]:
         """
-        get a vector from the vector storage by key
+        Retrieve vectors from the vector storage by key.
+
+        Args:
+            name: The name of the vector collection
+            key: The key to search for
+
+        Returns:
+            list[VectorSearchResult]: List of matching vector search results. Returns empty list
+                if no matches found.
+
+        Raises:
+            Exception: If the retrieval operation fails
         """
         with self.tracer.start_as_current_span("agentuity.vector.get") as span:
             span.set_attribute("name", name)
@@ -113,7 +147,21 @@ class VectorStore:
         metadata: Optional[dict] = {},
     ) -> list[VectorSearchResult]:
         """
-        search for vectors in the vector storage
+        Search for vectors in the vector storage using semantic similarity.
+
+        Args:
+            name: The name of the vector collection
+            query: The search query string
+            limit: Maximum number of results to return (default: 10)
+            similarity: Minimum similarity threshold between 0.0 and 1.0 (default: 0.5)
+            metadata: Optional metadata filters to apply to the search
+
+        Returns:
+            list[VectorSearchResult]: List of matching vector search results. Returns empty list
+                if no matches found.
+
+        Raises:
+            Exception: If the search operation fails
         """
         with self.tracer.start_as_current_span("agentuity.vector.search") as span:
             span.set_attribute("name", name)
@@ -168,7 +216,17 @@ class VectorStore:
 
     async def delete(self, name: str, key: str) -> int:
         """
-        delete a vector from the vector storage
+        Delete vectors from the vector storage by key.
+
+        Args:
+            name: The name of the vector collection
+            key: The key of the vectors to delete
+
+        Returns:
+            int: Number of vectors deleted
+
+        Raises:
+            Exception: If the deletion operation fails
         """
         with self.tracer.start_as_current_span("agentuity.vector.delete") as span:
             span.set_attribute("name", name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "aiohttp>=3.11.13",
     "asyncio>=3.4.3",
     "httpx>=0.28.1",
+    "aiohttp-sse>=2.2.0",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,7 @@ name = "agentuity"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
+    { name = "aiohttp-sse" },
     { name = "asyncio" },
     { name = "httpx" },
     { name = "opentelemetry-api" },
@@ -20,6 +21,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.11.13" },
+    { name = "aiohttp-sse", specifier = ">=2.2.0" },
     { name = "asyncio", specifier = ">=3.4.3" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "opentelemetry-api", specifier = ">=1.21.0" },
@@ -120,6 +122,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/cd/68030356eb9a7d57b3e2823c8a852709d437abb0fbff41a61ebc351b7625/aiohttp-3.11.13-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b992778d95b60a21c4d8d4a5f15aaab2bd3c3e16466a72d7f9bfd86e8cea0d4b", size = 1673166 },
     { url = "https://files.pythonhosted.org/packages/03/61/425397a9a2839c609d09fdb53d940472f316a2dbeaa77a35b2628dae6284/aiohttp-3.11.13-cp313-cp313-win32.whl", hash = "sha256:507ab05d90586dacb4f26a001c3abf912eb719d05635cbfad930bdbeb469b36c", size = 410615 },
     { url = "https://files.pythonhosted.org/packages/9c/54/ebb815bc0fe057d8e7a11c086c479e972e827082f39aeebc6019dd4f0862/aiohttp-3.11.13-cp313-cp313-win_amd64.whl", hash = "sha256:5ceb81a4db2decdfa087381b5fc5847aa448244f973e5da232610304e199e7b2", size = 436452 },
+]
+
+[[package]]
+name = "aiohttp-sse"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/df/4ddb30e689695fd91cf41c072e154061120ed166e8baf6c9a0020f27dffc/aiohttp-sse-2.2.0.tar.gz", hash = "sha256:a48dd5774031d3f41a29e159ebdbb93e89c8f37c1e9e83e196296be51885a5c2", size = 9432 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/b8/bf448b1d2dbe6cf16c3be0b92230a8f032f2f0ed159a2299284c709819c8/aiohttp_sse-2.2.0-py3-none-any.whl", hash = "sha256:339f9803bcf4682a2060e75548760d86abe4424a0d92ba66ff4985de3bd743dc", size = 6740 },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds SSE support with stream response. You can also call resp.stream with non-SSE too.


```python
from openai import OpenAI
from agentuity import AgentRequest, AgentResponse, AgentContext

client = OpenAI()


async def run(request: AgentRequest, response: AgentResponse, context: AgentContext):
    chat_completion = client.chat.completions.create(
        messages=[
            {
                "role": "system",
                "content": "You are a friendly assistant!",
            },
            {
                "role": "user",
                "content": request.data.text or "Why is the sky blue?",
            },
        ],
        model="gpt-4o",
        stream=True,
    )
    return response.stream(chat_completion, lambda x: x.choices[0].delta.content)
```

If you include `Accept: text/event-stream` when running the agent, the data will stream using the SSE protocol.

If you don't include this header, it will stream the response in the normal format.