### PR TITLE
Email: text and html should return a str not a list of str to match JS behavior

### DIFF
--- a/agentuity/io/email.py
+++ b/agentuity/io/email.py
@@ -258,14 +258,14 @@ class Email(EmailInterface):
         """
         Return the text of the email.
         """
-        return getattr(self._email, "text_plain", "")
+        return "\n".join(getattr(self._email, "text_plain", ""))
 
     @property
     def html(self) -> str:
         """
         Return the html of the email.
         """
-        return getattr(self._email, "text_html", "")
+        return "\n".join(getattr(self._email, "text_html", ""))
 
     @property
     def attachments(self) -> List["IncomingEmailAttachment"]:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated email content handling so that plain text and HTML outputs are now returned as single strings with proper formatting, instead of lists or unformatted content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->