### PR TITLE
Enable the ability to use custom email domains for email replies

### DIFF
--- a/agentuity/apis/discord.py
+++ b/agentuity/apis/discord.py
@@ -8,11 +8,7 @@ from agentuity.server.types import DiscordServiceInterface
 
 class DiscordApi(DiscordServiceInterface):
     async def send_reply(
-        self,
-        agent_id: str,
-        message_id: str,
-        channel_id: str,
-        content: str
+        self, agent_id: str, message_id: str, channel_id: str, content: str
     ) -> None:
         tracer = trace.get_tracer("discord")
         with tracer.start_as_current_span("agentuity.discord.reply") as span:
@@ -20,9 +16,13 @@ class DiscordApi(DiscordServiceInterface):
             span.set_attribute("@agentuity/discordMessageId", message_id)
             span.set_attribute("@agentuity/discordChannelId", channel_id)
 
-            api_key = os.environ.get("AGENTUITY_SDK_KEY") or os.environ.get("AGENTUITY_API_KEY")
-            base_url = os.environ.get("AGENTUITY_TRANSPORT_URL", "https://api.agentuity.com")
-            
+            api_key = os.environ.get("AGENTUITY_SDK_KEY") or os.environ.get(
+                "AGENTUITY_API_KEY"
+            )
+            base_url = os.environ.get(
+                "AGENTUITY_TRANSPORT_URL", "https://api.agentuity.com"
+            )
+
             headers = {
                 "Authorization": f"Bearer {api_key}",
                 "User-Agent": f"Agentuity Python SDK/{__version__}",
@@ -41,4 +41,6 @@ class DiscordApi(DiscordServiceInterface):
             async with httpx.AsyncClient() as client:
                 response = await client.post(url, json=payload, headers=headers)
                 if response.status_code != 200:
-                    raise ValueError(f"Error sending discord reply: {response.text} ({response.status_code})")
+                    raise ValueError(
+                        f"Error sending discord reply: {response.text} ({response.status_code})"
+                    )

--- a/agentuity/io/discord.py
+++ b/agentuity/io/discord.py
@@ -12,7 +12,7 @@ class DiscordMessage(DiscordMessageInterface):
             data = json.loads(message)
             if not self._is_valid_discord_message(data):
                 raise ValueError("Invalid discord message format")
-            
+
             self._guild_id = data.get("guildId", "")
             self._channel_id = data["channelId"]
             self._message_id = data["messageId"]
@@ -54,15 +54,13 @@ class DiscordMessage(DiscordMessageInterface):
         self,
         request: AgentRequestInterface,
         context: AgentContextInterface,
-        content: str
+        content: str,
     ) -> None:
         from agentuity.apis.discord import DiscordApi
+
         discord_api = DiscordApi()
         await discord_api.send_reply(
-            context.agentId,
-            self._message_id,
-            self._channel_id,
-            content
+            context.agentId, self._message_id, self._channel_id, content
         )
 
     def __repr__(self) -> str:
@@ -71,6 +69,6 @@ class DiscordMessage(DiscordMessageInterface):
 
 async def parse_discord_message(data: bytes) -> DiscordMessage:
     try:
-        return DiscordMessage(data.decode('utf-8'))
+        return DiscordMessage(data.decode("utf-8"))
     except Exception as error:
         raise ValueError(f"Failed to parse discord: {str(error)}") from error

--- a/agentuity/io/email.py
+++ b/agentuity/io/email.py
@@ -283,6 +283,8 @@ class Email(EmailInterface):
         text: str = None,
         html: str = None,
         attachments: List["OutgoingEmailAttachmentInterface"] = None,
+        from_email: str = None,
+        from_name: str = None,
     ):
         """
         Send a reply to this email using the Agentuity email API.
@@ -294,6 +296,8 @@ class Email(EmailInterface):
             body (str): Plain text body of the reply.
             html (str): HTML body of the reply.
             attachments (list): List of file-like objects or dicts with 'filename' and 'content'.
+            from_email (str): Email address of the sender. Defaults to the original sender if not provided. Can only be overridden if custom email sending is enabled.
+            from_name (str): Name of the sender. Defaults to the original sender if not provided.
         """
         tracer = trace.get_tracer("email")
         with tracer.start_as_current_span("agentuity.email.reply") as span:
@@ -324,7 +328,9 @@ class Email(EmailInterface):
             outer["In-Reply-To"] = self.message_id
             outer["References"] = self.message_id
             outer["Subject"] = subject or f"Re: {self.subject}"
-            outer["From"] = formataddr((self.to_name or context.agent.name, self.to))
+            outer["From"] = formataddr(
+                (from_name or self.to_name or context.agent.name, from_email or self.to)
+            )
             outer["To"] = formataddr((self.from_name, self.from_email))
             outer["Date"] = datetime.now().isoformat()
 

--- a/agentuity/server/data.py
+++ b/agentuity/server/data.py
@@ -69,7 +69,7 @@ class StringStreamReader(StreamReader):
     def read_sync(self) -> bytes:
         if self._eof:
             return b""
-        data = self._data[self._pos:]
+        data = self._data[self._pos :]
         self._pos = len(self._data)
         self._eof = True
         return data
@@ -90,7 +90,7 @@ class StringStreamReader(StreamReader):
         remaining = len(self._data) - self._pos
         if n > remaining:
             raise ValueError("Not enough data to read")
-        data = self._data[self._pos: self._pos + n]
+        data = self._data[self._pos : self._pos + n]
         self._pos += n
         if self._pos >= len(self._data):
             self._eof = True
@@ -99,7 +99,7 @@ class StringStreamReader(StreamReader):
     async def readline(self) -> bytes:
         if self._eof:
             return b""
-        data = self._data[self._pos:]
+        data = self._data[self._pos :]
         self._pos = len(self._data)
         self._eof = True
         return data
@@ -107,7 +107,7 @@ class StringStreamReader(StreamReader):
     async def readchunk(self) -> tuple[bytes, bool]:
         if self._eof:
             return b"", True
-        data = self._data[self._pos:]
+        data = self._data[self._pos :]
         self._pos = len(self._data)
         self._eof = True
         return data, True
@@ -131,8 +131,7 @@ class StringStreamReader(StreamReader):
         self._eof = True
 
     def feed_data(self, data: bytes) -> None:
-        raise NotImplementedError(
-            "StringStreamReader does not support feeding data")
+        raise NotImplementedError("StringStreamReader does not support feeding data")
 
     def begin_http_chunk_receiving(self) -> None:
         pass
@@ -151,7 +150,7 @@ class BytesStreamReader(StreamReader):
     def read_sync(self) -> bytes:
         if self._eof:
             return b""
-        data = self._data[self._pos:]
+        data = self._data[self._pos :]
         self._pos = len(self._data)
         self._eof = True
         return data
@@ -172,7 +171,7 @@ class BytesStreamReader(StreamReader):
         remaining = len(self._data) - self._pos
         if n > remaining:
             raise ValueError("Not enough data to read")
-        data = self._data[self._pos: self._pos + n]
+        data = self._data[self._pos : self._pos + n]
         self._pos += n
         if self._pos >= len(self._data):
             self._eof = True
@@ -181,7 +180,7 @@ class BytesStreamReader(StreamReader):
     async def readline(self) -> bytes:
         if self._eof:
             return b""
-        data = self._data[self._pos:]
+        data = self._data[self._pos :]
         self._pos = len(self._data)
         self._eof = True
         return data
@@ -189,7 +188,7 @@ class BytesStreamReader(StreamReader):
     async def readchunk(self) -> tuple[bytes, bool]:
         if self._eof:
             return b"", True
-        data = self._data[self._pos:]
+        data = self._data[self._pos :]
         self._pos = len(self._data)
         self._eof = True
         return data, True
@@ -213,8 +212,7 @@ class BytesStreamReader(StreamReader):
         self._eof = True
 
     def feed_data(self, data: bytes) -> None:
-        raise NotImplementedError(
-            "BytesStreamReader does not support feeding data")
+        raise NotImplementedError("BytesStreamReader does not support feeding data")
 
     def begin_http_chunk_receiving(self) -> None:
         pass
@@ -387,8 +385,7 @@ class Data(DataInterface):
             elif hasattr(self._stream, "read"):
                 # Avoid instantiating a coroutine – check the *function* first
                 if asyncio.iscoroutinefunction(self._stream.read):
-                    raise RuntimeError(
-                        "This Data instance requires async access")
+                    raise RuntimeError("This Data instance requires async access")
                 data = self._stream.read()  # guaranteed to be bytes now
                 self._data = data
                 self._loaded = True
@@ -507,8 +504,7 @@ class IteratorStreamReader(StreamReader):
         self._eof = True
 
     def feed_data(self, data: bytes) -> None:
-        raise NotImplementedError(
-            "IteratorStreamReader does not support feeding data")
+        raise NotImplementedError("IteratorStreamReader does not support feeding data")
 
     def begin_http_chunk_receiving(self) -> None:
         pass
@@ -750,8 +746,7 @@ def dataLikeToData(value: DataLike, content_type: str = None) -> Data:
     elif isinstance(value, collections.abc.AsyncIterator):
         content_type = content_type or "application/octet-stream"
         return Data(
-            content_type, AsyncIteratorStreamReader(
-                ValidatedAsyncIterator(value))
+            content_type, AsyncIteratorStreamReader(ValidatedAsyncIterator(value))
         )
     else:
         raise ValueError(f"Unsupported value type: {type(value)}")

--- a/agentuity/server/types.py
+++ b/agentuity/server/types.py
@@ -213,7 +213,7 @@ class DiscordMessageInterface(ABC):
         self,
         request: "AgentRequestInterface",
         context: "AgentContextInterface",
-        content: str
+        content: str,
     ) -> None:
         pass
 
@@ -221,10 +221,6 @@ class DiscordMessageInterface(ABC):
 class DiscordServiceInterface(ABC):
     @abstractmethod
     async def send_reply(
-        self,
-        agent_id: str,
-        message_id: str,
-        channel_id: str,
-        content: str
+        self, agent_id: str, message_id: str, channel_id: str, content: str
     ) -> None:
         pass


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a custom sender name and email address when sending email replies.

* **Style**
  * Improved code formatting and consistency across Discord and email modules, including parameter formatting and whitespace adjustments.
  * Updated docstrings to reflect new email reply options.
  * Minor stylistic changes to internal data handling and type definitions for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->